### PR TITLE
챌린지 api 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 	// Jackson Data Bind
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
 
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kdt/wolf/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/kdt/wolf/domain/challenge/controller/ChallengeController.java
@@ -27,7 +27,7 @@ public class ChallengeController {
 
     // 챌린지(단일) 조회
     @GetMapping("/challenge/{challengePostId}")
-    public ApiResult<ChallengeDto.ChallengePreview> getChallenge(@PathVariable Long challengePostId){
+    public ApiResult<ChallengeDto.ChallengeDetail> getChallenge(@PathVariable Long challengePostId){
         return ApiResult.ok(challengeService.getChallenge(challengePostId));
     }
 
@@ -45,8 +45,8 @@ public class ChallengeController {
 
     // 그룹장 신청
     @PostMapping("/registration")
-    public ApiResult<?> challengeRegistration(@RequestBody ChallengeRegistrationRequest request){
-        challengeService.createChallengeRegistration(request);
+    public ApiResult<?> challengeRegistration(@RequestBody ChallengeRegistrationRequest request, @AuthenticationPrincipal AuthenticatedUser user){
+        challengeService.createChallengeRegistration(request, user.getUserId());
         return ApiResult.ok();
     }
 

--- a/src/main/java/com/kdt/wolf/domain/challenge/dao/ChallengePostDao.java
+++ b/src/main/java/com/kdt/wolf/domain/challenge/dao/ChallengePostDao.java
@@ -84,17 +84,22 @@ public class ChallengePostDao {
 
 
     // 챌린지 신청(그룹장)
-    public void createChallengeRegistration(ChallengeRegistrationRequest request) {
+    public void createChallengeRegistration(ChallengeRegistrationRequest request, Long userId) {
         GroupPostEntity group = groupPostRepository.findById(request.getGroupPostId()).orElseThrow(NotFoundException::new);
         ChallengePostEntity challengePost = challengePostRepository.findById(request.getChallengePostId()).orElseThrow(NotFoundException::new);
+        UserEntity user = userRepository.findById(userId).orElseThrow(NotFoundException::new);
 
-        ChallengeRegistrationEntity entity = new ChallengeRegistrationEntity(
+        ChallengeRegistrationEntity registration = new ChallengeRegistrationEntity(
                 challengePost,
                 group,
                 Long.parseLong(request.getChallengeAmount() == null ? "0" :request.getChallengeAmount())
         );
 
-        challengeRegistrationQueryRepository.save(entity);
+        challengeRegistrationQueryRepository.save(registration);
+
+        GroupChallengeParticipantEntity participantEntity = new GroupChallengeParticipantEntity(registration, user);
+        participantEntity.updatePaymentStatus();
+        groupChallengeParticipantRepository.save(participantEntity);
     }
 
     // 챌린지 참여

--- a/src/main/java/com/kdt/wolf/domain/challenge/dto/ChallengeDto.java
+++ b/src/main/java/com/kdt/wolf/domain/challenge/dto/ChallengeDto.java
@@ -28,6 +28,27 @@ public class ChallengeDto {
         }
     }
 
+    @Getter
+    public static class ChallengeDetail{
+        private final Long challengeId;
+        private final String title;
+        private final String registrationDate;
+        private final String deadline;
+        private final String content;
+        private final String manner;
+        private final String awardContent;
+
+        public ChallengeDetail(Long challengeId, String title, LocalDate registrationDate, LocalDate deadline, String content, String manner, String awardContent) {
+            this.challengeId = challengeId;
+            this.title = title;
+            this.registrationDate = registrationDate.toString();
+            this.deadline = deadline.toString();
+            this.content = content;
+            this.manner = manner;
+            this.awardContent = awardContent;
+        }
+    }
+
     public record ChallengePageResponse(
             List<ChallengePreview> challenges,
             PageResponse page

--- a/src/main/java/com/kdt/wolf/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/kdt/wolf/domain/challenge/service/ChallengeService.java
@@ -3,6 +3,7 @@ package com.kdt.wolf.domain.challenge.service;
 import com.kdt.wolf.domain.challenge.dao.ChallengePostDao;
 import com.kdt.wolf.domain.challenge.dto.ChallengeAdminDto.VerificationDetail;
 import com.kdt.wolf.domain.challenge.dto.ChallengeAdminDto.VerificationPreview;
+import com.kdt.wolf.domain.challenge.dto.ChallengeDto;
 import com.kdt.wolf.domain.challenge.dto.ChallengeDto.ChallengePageResponse;
 import com.kdt.wolf.domain.challenge.dto.ChallengeDto.ChallengePreview;
 import com.kdt.wolf.domain.challenge.dto.ChallengeStatus;
@@ -32,15 +33,16 @@ public class ChallengeService {
     private final ChallengePaymentRepository challengePaymentRepository;
 
     //챌린지 불러오기
-    public ChallengePreview getChallenge(Long challengePostId){
+    public ChallengeDto.ChallengeDetail getChallenge(Long challengePostId){
         ChallengePostEntity post = challengePostDao.findById(challengePostId);
-        return new ChallengePreview(
+        return new ChallengeDto.ChallengeDetail(
                 post.getChallengePostId(),
-                post.getImg(),
                 post.getTitle(),
                 post.getCreatedTime().toLocalDate(),
                 post.getDeadline(),
-                null
+                post.getContent(),
+                post.getManner(),
+                post.getAwardContent()
         );
     }
 
@@ -95,8 +97,8 @@ public class ChallengeService {
     }
 
     // 챌린지 신청
-    public void createChallengeRegistration(ChallengeRegistrationRequest request){
-        challengePostDao.createChallengeRegistration(request);
+    public void createChallengeRegistration(ChallengeRegistrationRequest request, Long userId){
+        challengePostDao.createChallengeRegistration(request, userId);
     }
 
     // 챌린지 참여
@@ -106,6 +108,7 @@ public class ChallengeService {
 
     // 챌린지 인증
     public void updateVerification(ChallengeVerificationRequest request, Long userId){
+
         challengePostDao.updateVerification(request, userId);
     }
 


### PR DESCRIPTION
## 설명
- 프론트에 - 백엔드 api 요청간 맞지 않는 url이나 데이터를 수정했습니다.

## 완료한 기능 명세
- 챌린지 목록 불러오기, 챌린지 상세 정보 불러오기, 챌린지 신청, 챌린지 참여, 챌린지 결제, 챌린지 인증
- 챌린지 결과 보기는 테스트해봐야 할 것 같습니다.
