### PR TITLE
Fix/fix user api

### DIFF
--- a/src/main/java/com/kdt/wolf/domain/alert/dao/AlertDao.java
+++ b/src/main/java/com/kdt/wolf/domain/alert/dao/AlertDao.java
@@ -3,6 +3,7 @@ package com.kdt.wolf.domain.alert.dao;
 import com.kdt.wolf.domain.alert.dto.AlertDto.AlertResponse;
 import com.kdt.wolf.domain.alert.entity.AlertEntity;
 import com.kdt.wolf.domain.alert.repository.AlertRepository;
+import com.kdt.wolf.global.exception.NotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,7 @@ public class AlertDao {
                 .map(alert -> {
                     alert.makeRead();
                     return new AlertResponse(
+                            alert.getType().getType(),
                             alert.getAlertContent(),
                             alert.getAlertLink(),
                             alert.getCreatedTime()
@@ -33,6 +35,7 @@ public class AlertDao {
         return alerts
                 .stream()
                 .map(alert -> new AlertResponse(
+                        alert.getType().getType(),
                         alert.getAlertContent(),
                         alert.getAlertLink(),
                         alert.getCreatedTime()
@@ -41,5 +44,10 @@ public class AlertDao {
     }
     public void saveAlert(AlertEntity alert) {
         alertRepository.save(alert);
+    }
+
+    public AlertEntity getAlarm(Long alertId) {
+        return alertRepository.findById(alertId)
+                .orElseThrow(NotFoundException::new);
     }
 }

--- a/src/main/java/com/kdt/wolf/domain/alert/dto/AlertDto.java
+++ b/src/main/java/com/kdt/wolf/domain/alert/dto/AlertDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public class AlertDto {
 
     public record AlertResponse(
+            String alertType,
             String alertContent,
             String alertLink,
             LocalDateTime alertTime

--- a/src/main/java/com/kdt/wolf/domain/alert/service/AlertService.java
+++ b/src/main/java/com/kdt/wolf/domain/alert/service/AlertService.java
@@ -54,4 +54,10 @@ public class AlertService {
     public String sendAlert(AlertRequest request) {
         return fcmService.sendNotificationByToken(request.toFCMNotificationRequestDto());
     }
+
+    public Long readAlarm(Long alertId) {
+        AlertEntity alert = alertDao.getAlarm(alertId);
+        alert.makeRead();
+        return alert.getAlertId();
+    }
 }

--- a/src/main/java/com/kdt/wolf/domain/user/controller/UserController.java
+++ b/src/main/java/com/kdt/wolf/domain/user/controller/UserController.java
@@ -71,4 +71,11 @@ public class UserController {
         return ApiResult.ok(response);
     }
 
+    @Operation(summary = "알람 읽음 처리")
+    @PostMapping("/alarms/{alertId}")
+    public ApiResult<Long> readAlarm(@PathVariable Long alertId) {
+        Long alarmId = alertService.readAlarm(alertId);
+        return ApiResult.ok(alarmId);
+    }
+
 }

--- a/src/main/java/com/kdt/wolf/domain/user/controller/UserController.java
+++ b/src/main/java/com/kdt/wolf/domain/user/controller/UserController.java
@@ -49,6 +49,12 @@ public class UserController {
         return ApiResult.ok(response);
     }
 
+    @Operation(summary = "사용 가능한 닉네임 조회 / true : 사용 가능")
+    public ApiResult<Boolean> isNicknameAvailable (@RequestBody String nickname) {
+        boolean isAvailable = userService.isNicknameAvailable(nickname);
+        return ApiResult.ok(isAvailable);
+    }
+
     @PostMapping("/sign-up")
     public ApiResult<?> completeSignUpProcess(@RequestBody SignUpRequest request,
                                               @AuthenticationPrincipal AuthenticatedUser user) {

--- a/src/main/java/com/kdt/wolf/domain/user/dao/UserDao.java
+++ b/src/main/java/com/kdt/wolf/domain/user/dao/UserDao.java
@@ -32,8 +32,12 @@ public class UserDao {
     public UserLoginResult signUpOrSignIn(OAuth2UserInfo userInfo) {
         Optional<UserEntity> user = userRepository.findByEmail(userInfo.getEmail());
         if(user.isPresent()) {
+            if(user.get().getNickname().isEmpty()) {
+                return new UserLoginResult(user.get(), LoginFlag.SIGNUP);
+            }
             return new UserLoginResult(user.get(), LoginFlag.LOGIN);
         }
+
         UserEntity newUser = userRepository.save(userInfo.toEntity());
         return new UserLoginResult(newUser, LoginFlag.SIGNUP);
     }

--- a/src/main/java/com/kdt/wolf/domain/user/dao/UserDao.java
+++ b/src/main/java/com/kdt/wolf/domain/user/dao/UserDao.java
@@ -107,4 +107,9 @@ public class UserDao {
         }
         return user.getUserId();
     }
+
+    public boolean isNicknameAvailable(String nickname) {
+        //이미 존재하면 ? userRepository.existsByNickname(nickname) -> true
+        return !userRepository.existsByNickname(nickname);
+    }
 }

--- a/src/main/java/com/kdt/wolf/domain/user/dao/UserDao.java
+++ b/src/main/java/com/kdt/wolf/domain/user/dao/UserDao.java
@@ -50,7 +50,8 @@ public class UserDao {
                 request.jobTitle(),
                 request.organization(),
                 request.experience(),
-                request.interests()
+                request.interests(),
+                request.currentStatus()
         );
         saveUser(user);
     }

--- a/src/main/java/com/kdt/wolf/domain/user/dto/SignUpDto.java
+++ b/src/main/java/com/kdt/wolf/domain/user/dto/SignUpDto.java
@@ -6,6 +6,7 @@ public class SignUpDto {
             String organization,
             int experience,
 
+            String currentStatus,
             String interests,
             String nickname
     ) {

--- a/src/main/java/com/kdt/wolf/domain/user/dto/UserDto.java
+++ b/src/main/java/com/kdt/wolf/domain/user/dto/UserDto.java
@@ -7,7 +7,14 @@ public class UserDto {
     public record UserProfileResponse(
             Long id,
             String nickname,
+            String name,
             String profilePicture,
+
+            String jobTitle,
+            String organization,
+            int experience,
+
+            String introduction,
             ActivityMetric activityMetric
     ) {}
 

--- a/src/main/java/com/kdt/wolf/domain/user/dto/UserDto.java
+++ b/src/main/java/com/kdt/wolf/domain/user/dto/UserDto.java
@@ -42,6 +42,7 @@ public class UserDto {
             String organization,
             int experience,
             String interests,
+            String currentStatus,
             String refundAccount,
             String introduction,
             List<UserLinkUpdateRequest> links

--- a/src/main/java/com/kdt/wolf/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/kdt/wolf/domain/user/entity/UserEntity.java
@@ -36,6 +36,9 @@ public class UserEntity extends BaseTimeEntity {
     private String jobTitle;
     private String organization;
     private int experience;
+
+    // 사용자 현재 상태 (예: 스터디 그룹을 찾고 있어요)
+    private String currentStatus;
     private String interests;
     private String refundAccount;
     private String introduction;
@@ -64,11 +67,12 @@ public class UserEntity extends BaseTimeEntity {
         this.activityMetrics = new ActivityMetricsEntity(this);
     }
 
-    public void updateDetailProfile(String jobTitle, String organization, int experience, String interests) {
+    public void updateDetailProfile(String jobTitle, String organization, int experience, String interests, String currentStatus) {
         this.jobTitle = jobTitle;
         this.organization = organization;
         this.experience = experience;
         this.interests = interests;
+        this.currentStatus = currentStatus;
     }
 
     public void updateNickname(String nickname) {
@@ -82,7 +86,8 @@ public class UserEntity extends BaseTimeEntity {
                 request.jobTitle(),
                 request.organization(),
                 request.experience(),
-                request.interests()
+                request.interests(),
+                request.currentStatus()
         );
         return this;
     }

--- a/src/main/java/com/kdt/wolf/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kdt/wolf/domain/user/repository/UserRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
@@ -17,4 +19,9 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @EntityGraph(attributePaths = {"activityMetrics"})
     @NonNull
     List<UserEntity> findAll();
+
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN TRUE ELSE FALSE END "
+            + "FROM UserEntity u "
+            + "WHERE u.nickname = :nickname AND u.status = 'ACTIVE'")
+    boolean existsByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/com/kdt/wolf/domain/user/service/UserService.java
+++ b/src/main/java/com/kdt/wolf/domain/user/service/UserService.java
@@ -182,4 +182,8 @@ public class UserService {
 
         return  userDao.panaltyUser(user, reportAction);
     }
+
+    public boolean isNicknameAvailable(String nickname) {
+        return userDao.isNicknameAvailable(nickname);
+    }
 }

--- a/src/main/java/com/kdt/wolf/domain/user/service/UserService.java
+++ b/src/main/java/com/kdt/wolf/domain/user/service/UserService.java
@@ -58,7 +58,14 @@ public class UserService {
         return new UserProfileResponse(
                 user.getUserId(),
                 user.getNickname(),
+                user.getName(),
                 user.getProfilePicture(),
+
+                user.getJobTitle(),
+                user.getOrganization(),
+                user.getExperience(),
+
+                user.getIntroduction(),
                 user.getActivityMetrics().toResponse()
         );
     }


### PR DESCRIPTION
## 완료한 기능 명세
- [x] **닉네임이 없을 경우 SIGNUP을 리턴하도록 수정**
  
- [x] **남의 프로필 조회 response 수정**
  
- [x] **알림 읽음 처리 API 생성 및 response에 타임 추가**
  
- [x] **사용 가능한 닉네임 조회 API 생성**
  
- [x] **interest -> 상태, 기술로 분리**